### PR TITLE
make adb wait instead of just sleeping for a fixed ammount

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,11 @@ android {
         disable 'GradleDependency'
     }
 
+    adbOptions {
+        // avoid the com.android.builder.testing.api.DeviceException: com.android.ddmlib.ShellCommandUnresponsiveException
+        timeOutInMs 90 * 1000
+    }
+
     dexOptions {
         if(isCi) {
             // CircleCi allow max 4G memory for all processes together and dex does exceed it

--- a/circle.yml
+++ b/circle.yml
@@ -40,10 +40,6 @@ test:
 
     # ensure that the emulator is ready to use
     - circle-android wait-for-boot
-    # the necessary sleep duration may change with time and depends on the pre tasks length.
-    # When all pre tasks are run long enough then waiting will not be necessary anymore.
-    # This sleep should avoid the com.android.builder.testing.api.DeviceException: com.android.ddmlib.ShellCommandUnresponsiveException
-    - sleep 60
     # at least remove the look screen
     - adb shell input keyevent 82
 


### PR DESCRIPTION
As of gradle 1.2, the adb timeout can be modified so that instead of sleeping for a minute for the emulator to be alive, adb waits as needed.

https://code.google.com/p/android/issues/detail?id=104305